### PR TITLE
remove contentHeight logic 

### DIFF
--- a/src/components/lazy-loader.svelte
+++ b/src/components/lazy-loader.svelte
@@ -3,18 +3,21 @@
 
  export let loadItems; // Funkce pro načtení více dat
  export let items;
- export let contentHeight;
+ export let contentElement;
 
  const threshold = 0.1; // Prahová hodnota pro IntersectionObserver
 
  let hasMore = true; // Indikátor, zda je více dat k načtení
  let loading = false;
- let count = 1;
+ let count = 10;
  let offset = 0;
  let observer;
  let loaderElement;
  let timer;
+ let _loaderIsVisible = true;
 
+ /*let contentHeight;
+ $: contentHeight = contentElement ? contentElement.clientHeight : null;*/
 
  export function reload() {
   reset();
@@ -33,7 +36,6 @@
   loading = true;
   loadItems(
    res => {
-    console.log(res)
     if (res.error === 0) {
      items = [...items, ...res.items];
      console.log('items.length:' + items.length);
@@ -59,23 +61,31 @@
 
  function isLoaderVisible() {
   let result = false;
+  /*
   if (loaderElement) {
    const rect = loaderElement.getBoundingClientRect();
    result = rect.top < contentHeight;
-   //console.log('rect.top:' + rect.top + ', contentHeight:' + contentHeight);
-  } else result = false;
-  //console.log('isLoaderVisible:' + result);
+   console.log('rect.top:' + rect.top + ', contentHeight:' + contentHeight);
+  } else result = false;*/
+  result = _loaderIsVisible;
+  console.log('isLoaderVisible:' + result);
   return result;
  }
 
  function handleIntersect(entries) {
-  if (entries[0].isIntersecting && !loading && hasMore) {
+  console.log('handleIntersect:')
+  console.log(entries)
+
+  _loaderIsVisible = entries[0].isIntersecting;
+  if (_loaderIsVisible && !loading && hasMore) {
    loadMore();
   }
  }
 
  onMount(() => {
-  observer = new IntersectionObserver(handleIntersect, { threshold });
+  console.log('contentElement is ' + contentElement);
+  console.log('loaderElement is ' + loaderElement);
+  observer = new IntersectionObserver(handleIntersect, { threshold, root: contentElement });
   if (loaderElement) observer.observe(loaderElement);
  });
 

--- a/src/components/pages/domains-list.svelte
+++ b/src/components/pages/domains-list.svelte
@@ -6,7 +6,7 @@
  import ModalDomainsDel from '../modal-domains-del.svelte';
  import LazyLoader from '../lazy-loader.svelte';
 
- export let contentHeight;
+ export let contentElement;
 
  let items = [];
  let isModalAddEditOpen = false;
@@ -124,7 +124,7 @@
    {/each}
   </tbody>
  </table>
- <LazyLoader bind:this={lazyLoader} loadItems={loadItems} {contentHeight} bind:items={items} />
+ <LazyLoader bind:this={lazyLoader} loadItems={loadItems} {contentElement} bind:items={items} />
 </div>
 {#if isModalAddEditOpen}
  <Modal title={domainID ? 'Edit the domain' : 'Add a new domain'} onClose={onModalAddEditClose}>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -26,8 +26,6 @@
  let resizer;
  let isResizingSideBar = false;
  let contentElement;
- let contentHeight;
- $: contentHeight = contentElement ? contentElement.clientHeight : null;
 
  $: if ($isLoggedIn && $socketState === socketStates.OPEN) {
   console.log('Connected to server');
@@ -173,7 +171,7 @@
    <div class="resizer" role="none" bind:this={resizer} on:mousedown={startResizeSideBar}></div>
    <div class="content" bind:this={contentElement}>
     {#if selectedPage}
-     <svelte:component this={selectedPage} {contentHeight} />
+     <svelte:component this={selectedPage} {contentElement} />
     {:else}
      <WelcomeContent {product} {version} {link} />
     {/if}


### PR DESCRIPTION
remove contentHeight logic, because it does not work correctly when page is zooomed. Use IntersectionObserver even during loading. Set IntersectionObserver parent element to content component (not viewport).